### PR TITLE
Refactor Contentful rendering and Graphql queries

### DIFF
--- a/src/components/CodePen.tsx
+++ b/src/components/CodePen.tsx
@@ -1,3 +1,4 @@
+import { graphql } from 'gatsby';
 import * as React from 'react';
 import Codepen from 'react-codepen-embed';
 
@@ -26,3 +27,15 @@ const Pen: React.FC<PenProps> = ({
 );
 
 export default Pen;
+
+export const query = graphql`
+  fragment Pen on ContentfulCodePen {
+    contentful_id
+    __typename
+    hash
+    editable
+    height
+    defaultTab
+    showResult
+  }
+`;

--- a/src/components/ExternalLink.tsx
+++ b/src/components/ExternalLink.tsx
@@ -1,3 +1,4 @@
+import { graphql } from 'gatsby';
 import * as React from 'react';
 
 const ExternalLink = ({
@@ -15,3 +16,12 @@ const ExternalLink = ({
 };
 
 export default ExternalLink;
+
+export const query = graphql`
+  fragment ExternalLink on ContentfulExternalLink {
+    __typename
+    contentful_id
+    url
+    text
+  }
+`;

--- a/src/templates/contentfulPost.tsx
+++ b/src/templates/contentfulPost.tsx
@@ -1,126 +1,24 @@
-import React, { ReactNode, FC } from 'react';
+import React, { ReactNode } from 'react';
 import { graphql } from 'gatsby';
-import { ExternalLink, Pen } from '../components';
 import { Layout, ListTags, Seo } from '../components';
 import styled from 'styled-components';
-import { Options } from '@contentful/rich-text-react-renderer';
-import { BLOCKS, MARKS, INLINES } from '@contentful/rich-text-types';
 import { renderRichText } from 'gatsby-source-contentful/rich-text';
-import SyntaxHighlighter from 'react-syntax-highlighter';
-import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs';
-
-import { GatsbyImage } from 'gatsby-plugin-image';
-
-interface ChildProps {
-  children: ReactNode;
-}
-
-const Bold: FC<ChildProps> = ({ children }) => (
-  <span className="bold">{children}</span>
-);
-const Text: FC<ChildProps> = ({ children }) => (
-  <p className="align-center">{children}</p>
-);
-
-enum Tabs {
-  HTML = 'html',
-  CSS = 'css',
-  JS = 'js',
-  None = '',
-}
-
-const getTabs = (defaultTab: keyof typeof Tabs, showResult: boolean) => {
-  const result = [];
-  if (defaultTab !== 'None') {
-    result.push(Tabs[defaultTab]);
-  }
-  if (showResult) {
-    result.push('result');
-  }
-  return result.join(',');
-};
-
-const options: Options = {
-  renderMark: {
-    [MARKS.BOLD]: text => <Bold>{text}</Bold>,
-  },
-  renderNode: {
-    [BLOCKS.PARAGRAPH]: (node, children) => <Text>{children}</Text>,
-    [BLOCKS.EMBEDDED_ASSET]: node => {
-      if (node.data.target.__typename === 'ContentfulAsset') {
-        const { gatsbyImageData, description, title } = node.data.target;
-        return (
-          <GatsbyImage
-            image={gatsbyImageData}
-            alt={description}
-            title={title}
-          />
-        );
-      }
-      return (
-        <>
-          <h2>Embedded Asset</h2>
-          <pre>
-            <code>{JSON.stringify(node, null, 2)}</code>
-          </pre>
-        </>
-      );
-    },
-    [BLOCKS.EMBEDDED_ENTRY]: (node: any) => {
-      if (node.data.target.__typename === 'ContentfulCodeBlock') {
-        const { code, language, showLineNumbers } = node.data.target;
-        return (
-          <SyntaxHighlighter
-            language={language}
-            style={docco}
-            showLineNumbers={showLineNumbers}>
-            {code.code}
-          </SyntaxHighlighter>
-        );
-      }
-      if (node.data.target.__typename === 'ContentfulCodePen') {
-        const { hash, editable, height, defaultTab, showResult } =
-          node.data.target;
-        return (
-          <Pen
-            hash={hash}
-            editable={editable}
-            height={height}
-            defaultTab={getTabs(defaultTab, showResult)}
-          />
-        );
-      }
-      return (
-        <>
-          <h2>Embedded Entry</h2>
-          <pre>
-            <code>{JSON.stringify(node, null, 2)}</code>
-          </pre>
-        </>
-      );
-    },
-    [INLINES.EMBEDDED_ENTRY]: (node: any) => {
-      if (node.data.target.__typename === 'ContentfulExternalLink') {
-        const { url, text } = node.data.target;
-        return <ExternalLink text={text || url}>{url}</ExternalLink>;
-      }
-      return (
-        <>
-          <h2>Inline Entry</h2>
-          <pre>
-            <code>{JSON.stringify(node, null, 2)}</code>
-          </pre>
-        </>
-      );
-    },
-  },
-};
+import { options } from '../utils/options';
 
 const Date = styled.span`
   font-size: small;
 `;
 
 const ContentSection = styled.section`
+  margin-bottom: 1rem;
+`;
+
+const HeadingSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  > h1 {
+    margin-bottom: 0;
+  }
   margin-bottom: 1rem;
 `;
 
@@ -146,13 +44,10 @@ export default function ContentfulPageTemplate({
 
   return (
     <Layout>
-      <h1>
-        {title}
-        <Date title={dateDiff}>
-          <br />
-          {date}
-        </Date>
-      </h1>
+      <HeadingSection>
+        <h1>{title}</h1>
+        <Date title={dateDiff}>{date}</Date>
+      </HeadingSection>
       <ContentSection>{renderRichText(content, options)}</ContentSection>
       {tags && <ListTags tags={tags} />}
     </Layout>
@@ -172,25 +67,19 @@ export const query = graphql`
         raw
         references {
           ... on ContentfulCodePen {
-            contentful_id
-            __typename
-            hash
-            editable
-            height
-            defaultTab
-            showResult
+            ...Pen
           }
           ... on ContentfulExternalLink {
-            __typename
-            contentful_id
-            url
-            text
+            ...ExternalLink
           }
           ... on ContentfulAsset {
             __typename
             contentful_id
-            # gatsbyImageData(layout: CONSTRAINED)
-            gatsbyImageData
+            gatsbyImageData(
+              layout: CONSTRAINED
+              placeholder: BLURRED
+              width: 800
+            )
             description
             title
           }

--- a/src/utils/getTabs.tsx
+++ b/src/utils/getTabs.tsx
@@ -1,0 +1,16 @@
+enum Tabs {
+  HTML = 'html',
+  CSS = 'css',
+  JS = 'js',
+  None = '',
+}
+export const getTabs = (defaultTab: keyof typeof Tabs, showResult: boolean) => {
+  const result = [];
+  if (defaultTab !== 'None') {
+    result.push(Tabs[defaultTab]);
+  }
+  if (showResult) {
+    result.push('result');
+  }
+  return result.join(',');
+};

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -1,0 +1,2 @@
+export * from './getTabs';
+export * from './options';

--- a/src/utils/options.tsx
+++ b/src/utils/options.tsx
@@ -1,0 +1,93 @@
+import React, { ReactNode, FC } from 'react';
+import { ExternalLink, Pen } from '../components';
+import { Options } from '@contentful/rich-text-react-renderer';
+import { BLOCKS, MARKS, INLINES } from '@contentful/rich-text-types';
+import SyntaxHighlighter from 'react-syntax-highlighter';
+import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs';
+import { GatsbyImage } from 'gatsby-plugin-image';
+import { getTabs } from './getTabs';
+
+interface ChildProps {
+  children: ReactNode;
+}
+const Bold: FC<ChildProps> = ({ children }) => (
+  <span className="bold">{children}</span>
+);
+const Text: FC<ChildProps> = ({ children }) => (
+  <p className="align-center">{children}</p>
+);
+export const options: Options = {
+  renderMark: {
+    [MARKS.BOLD]: text => <Bold>{text}</Bold>,
+  },
+  renderNode: {
+    [BLOCKS.PARAGRAPH]: (node, children) => <Text>{children}</Text>,
+    [BLOCKS.EMBEDDED_ASSET]: node => {
+      if (node.data.target.__typename === 'ContentfulAsset') {
+        const { gatsbyImageData, description, title } = node.data.target;
+        return (
+          <GatsbyImage
+            image={gatsbyImageData}
+            alt={description}
+            title={title}
+          />
+        );
+      }
+      return (
+        <>
+          <h2>Embedded Asset</h2>
+          <pre>
+            <code>{JSON.stringify(node, null, 2)}</code>
+          </pre>
+        </>
+      );
+    },
+    [BLOCKS.EMBEDDED_ENTRY]: (node: any) => {
+      if (node.data.target.__typename === 'ContentfulCodeBlock') {
+        const { code, language, showLineNumbers } = node.data.target;
+        return (
+          <SyntaxHighlighter
+            language={language}
+            style={docco}
+            showLineNumbers={showLineNumbers}>
+            {code.code}
+          </SyntaxHighlighter>
+        );
+      }
+      if (node.data.target.__typename === 'ContentfulCodePen') {
+        const { hash, editable, height, defaultTab, showResult } =
+          node.data.target;
+        return (
+          <Pen
+            hash={hash}
+            editable={editable}
+            height={height}
+            defaultTab={getTabs(defaultTab, showResult)}
+          />
+        );
+      }
+      return (
+        <>
+          <h2>Embedded Entry</h2>
+          <pre>
+            <code>{JSON.stringify(node, null, 2)}</code>
+          </pre>
+        </>
+      );
+    },
+    [INLINES.EMBEDDED_ENTRY]: (node: any) => {
+      if (node.data.target.__typename === 'ContentfulExternalLink') {
+        const { url, text } = node.data.target;
+        return <ExternalLink text={text || url}>{url}</ExternalLink>;
+      }
+      return (
+        <>
+          <h2>Inline Entry</h2>
+          <pre>
+            <code>{JSON.stringify(node, null, 2)}</code>
+          </pre>
+        </>
+      );
+    },
+  },
+};


### PR DESCRIPTION
- Extracted common Graphql fragments for Contentful components, enhancing maintainability and reducing redundancy.
- Abstracted rendering logic for rich text fields into a utility module, ensuring clearer separation of concerns and making the rendering process more modular.
- Updated Contentful image queries to use 'CONSTRAINED' layout with 'BLURRED' placeholders for better loading performance and user experience.
- Created utility functions to handle tab generation logic, simplifying embedded content handling.
- Removed unused imports and simplified ContentfulPageTemplate, improving code readability and component efficiency.

This refactor makes future updates to Contentful content types and embedded entities easier to manage, while also improving code clarity and front-end performance.

#123 Refactor Contentful Components