### PR TITLE
Add content models for site management

### DIFF
--- a/content-models/codeBlock.js
+++ b/content-models/codeBlock.js
@@ -1,0 +1,65 @@
+module.exports = function (migration) {
+  const codeBlock = migration
+    .createContentType("codeBlock")
+    .name("Code block")
+    .description("")
+    .displayField("identifier");
+
+  codeBlock
+    .createField("identifier")
+    .name("Identifier")
+    .type("Symbol")
+    .localized(false)
+    .required(true)
+    .validations([
+      {
+        unique: true,
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  codeBlock
+    .createField("language")
+    .name("Language")
+    .type("Symbol")
+    .localized(false)
+    .required(true)
+    .validations([
+      {
+        in: ["javascript"],
+      },
+    ])
+    .defaultValue({
+      "en-US": "javascript",
+    })
+    .disabled(false)
+    .omitted(false);
+
+  codeBlock
+    .createField("showLineNumbers")
+    .name("Show line numbers?")
+    .type("Boolean")
+    .localized(false)
+    .required(false)
+    .validations([])
+    .defaultValue({
+      "en-US": false,
+    })
+    .disabled(false)
+    .omitted(false);
+
+  codeBlock
+    .createField("code")
+    .name("Code")
+    .type("Text")
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  codeBlock.changeFieldControl("identifier", "builtin", "singleLine", {});
+  codeBlock.changeFieldControl("language", "builtin", "dropdown", {});
+  codeBlock.changeFieldControl("showLineNumbers", "builtin", "boolean", {});
+  codeBlock.changeFieldControl("code", "builtin", "multipleLine", {});
+};

--- a/content-models/codePen.js
+++ b/content-models/codePen.js
@@ -1,0 +1,94 @@
+module.exports = function (migration) {
+  const codePen = migration
+    .createContentType("codePen")
+    .name("CodePen")
+    .description("")
+    .displayField("identifier");
+
+  codePen
+    .createField("identifier")
+    .name("Identifier")
+    .type("Symbol")
+    .localized(false)
+    .required(true)
+    .validations([
+      {
+        unique: true,
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  codePen
+    .createField("hash")
+    .name("Hash")
+    .type("Symbol")
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  codePen
+    .createField("height")
+    .name("Height")
+    .type("Integer")
+    .localized(false)
+    .required(false)
+    .validations([])
+    .defaultValue({
+      "en-US": 375,
+    })
+    .disabled(false)
+    .omitted(false);
+
+  codePen
+    .createField("showResult")
+    .name("Show result?")
+    .type("Boolean")
+    .localized(false)
+    .required(false)
+    .validations([])
+    .defaultValue({
+      "en-US": true,
+    })
+    .disabled(false)
+    .omitted(false);
+
+  codePen
+    .createField("defaultTab")
+    .name("Default tab")
+    .type("Symbol")
+    .localized(false)
+    .required(true)
+    .validations([
+      {
+        in: ["CSS", "HTML", "JS", "None"],
+      },
+    ])
+    .defaultValue({
+      "en-US": "None",
+    })
+    .disabled(false)
+    .omitted(false);
+
+  codePen
+    .createField("editable")
+    .name("Editable")
+    .type("Boolean")
+    .localized(false)
+    .required(true)
+    .validations([])
+    .defaultValue({
+      "en-US": false,
+    })
+    .disabled(false)
+    .omitted(false);
+
+  codePen.changeFieldControl("identifier", "builtin", "singleLine", {});
+  codePen.changeFieldControl("hash", "builtin", "singleLine", {});
+  codePen.changeFieldControl("height", "builtin", "numberEditor", {});
+  codePen.changeFieldControl("showResult", "builtin", "boolean", {});
+  codePen.changeFieldControl("defaultTab", "builtin", "radio", {});
+  codePen.changeFieldControl("editable", "builtin", "boolean", {});
+};

--- a/content-models/externalLink.js
+++ b/content-models/externalLink.js
@@ -1,0 +1,43 @@
+module.exports = function (migration) {
+  const externalLink = migration
+    .createContentType("externalLink")
+    .name("External Link")
+    .description("")
+    .displayField("identifier");
+
+  externalLink
+    .createField("identifier")
+    .name("Identifier")
+    .type("Symbol")
+    .localized(false)
+    .required(true)
+    .validations([
+      {
+        unique: true,
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  externalLink
+    .createField("text")
+    .name("Text")
+    .type("Symbol")
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  externalLink
+    .createField("url")
+    .name("URL")
+    .type("Symbol")
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  externalLink.changeFieldControl("identifier", "builtin", "singleLine", {});
+  externalLink.changeFieldControl("text", "builtin", "singleLine", {});
+  externalLink.changeFieldControl("url", "builtin", "urlEditor", {});
+};

--- a/content-models/post.js
+++ b/content-models/post.js
@@ -1,0 +1,165 @@
+module.exports = function (migration) {
+  const post = migration
+    .createContentType("post")
+    .name("Post")
+    .description("")
+    .displayField("slug");
+
+  post
+    .createField("slug")
+    .name("Slug")
+    .type("Symbol")
+    .localized(false)
+    .required(true)
+    .validations([
+      {
+        unique: true,
+      },
+      {
+        regexp: {
+          pattern: "^/[a-z-/]+$",
+          flags: null,
+        },
+
+        message: "Only slashes, lowercase characters, and hyphens are accepted",
+      },
+      {
+        prohibitRegexp: {
+          pattern: "/$",
+          flags: null,
+        },
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  post
+    .createField("date")
+    .name("Date")
+    .type("Date")
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  post
+    .createField("title")
+    .name("Title")
+    .type("Symbol")
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+  post
+    .createField("seoTitle")
+    .name("SEO title")
+    .type("Symbol")
+    .localized(false)
+    .required(true)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  post
+    .createField("postTags")
+    .name("Post Tags")
+    .type("Array")
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false)
+    .items({
+      type: "Link",
+
+      validations: [
+        {
+          linkContentType: ["postTags"],
+        },
+      ],
+
+      linkType: "Entry",
+    });
+
+  post
+    .createField("content")
+    .name("Content")
+    .type("RichText")
+    .localized(false)
+    .required(false)
+    .validations([
+      {
+        enabledMarks: [
+          "bold",
+          "italic",
+          "underline",
+          "code",
+          "superscript",
+          "subscript",
+        ],
+        message:
+          "Only bold, italic, underline, code, superscript, and subscript marks are allowed",
+      },
+      {
+        enabledNodeTypes: [
+          "heading-1",
+          "heading-2",
+          "heading-3",
+          "heading-4",
+          "heading-5",
+          "heading-6",
+          "ordered-list",
+          "unordered-list",
+          "hr",
+          "blockquote",
+          "embedded-entry-block",
+          "embedded-asset-block",
+          "table",
+          "asset-hyperlink",
+          "embedded-entry-inline",
+          "hyperlink",
+          "entry-hyperlink",
+        ],
+
+        message:
+          "Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, block entry, asset, table, link to asset, inline entry, link to Url, and link to entry nodes are allowed",
+      },
+      {
+        nodes: {
+          "embedded-entry-block": [
+            {
+              linkContentType: ["codePen", "codeBlock"],
+              message: null,
+            },
+          ],
+
+          "embedded-entry-inline": [
+            {
+              linkContentType: ["externalLink"],
+              message: null,
+            },
+          ],
+
+          "entry-hyperlink": [
+            {
+              linkContentType: ["post"],
+              message: null,
+            },
+          ],
+        },
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  post.changeFieldControl("slug", "builtin", "slugEditor", {
+    helpText: "Slashes, lowercase characters, and hyphens only",
+  });
+
+  post.changeFieldControl("date", "builtin", "datePicker", {});
+  post.changeFieldControl("title", "builtin", "singleLine", {});
+  post.changeFieldControl("seoTitle", "builtin", "singleLine", {});
+  post.changeFieldControl("postTags", "builtin", "entryLinksEditor", {});
+  post.changeFieldControl("content", "builtin", "richTextEditor", {});
+};

--- a/content-models/postTags.js
+++ b/content-models/postTags.js
@@ -1,0 +1,45 @@
+module.exports = function (migration) {
+  const postTags = migration
+    .createContentType("postTags")
+    .name("Post tags")
+    .description("")
+    .displayField("tag");
+
+  postTags
+    .createField("tag")
+    .name("Tag")
+    .type("Symbol")
+    .localized(false)
+    .required(true)
+    .validations([
+      {
+        unique: true,
+      },
+      {
+        regexp: {
+          pattern: "^[a-z-]+$",
+          flags: null,
+        },
+
+        message: "This field only accepts lowercase characters and hyphens",
+      },
+    ])
+    .disabled(false)
+    .omitted(false);
+
+  postTags
+    .createField("friendlyName")
+    .name("Friendly name")
+    .type("Symbol")
+    .localized(false)
+    .required(false)
+    .validations([])
+    .disabled(false)
+    .omitted(false);
+
+  postTags.changeFieldControl("tag", "builtin", "singleLine", {
+    helpText: "Lowercase characters and hyphens only",
+  });
+
+  postTags.changeFieldControl("friendlyName", "builtin", "singleLine", {});
+};


### PR DESCRIPTION
Introduced new content types with respective fields and validations for managing website content. These include models for posts, external links, code blocks, embedded CodePen instances, and post tags. Each model ensures data integrity with unique identifiers and specific field validations such as slug format for posts and lowercase enforcement for tags. Default values and UI controls were set up to improve content entry user experience.