### PR TITLE
Add typing for Contentful model references

### DIFF
--- a/src/components/sitemap.tsx
+++ b/src/components/sitemap.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { graphql, Link, useStaticQuery } from 'gatsby';
-// import styled from 'styled-components';
 
 const SiteMap = () => {
   const data = useStaticQuery(graphql`

--- a/src/templates/contentfulPost.tsx
+++ b/src/templates/contentfulPost.tsx
@@ -79,6 +79,7 @@ export const query = graphql`
         raw
         references {
           ... on ContentfulCodePen {
+            # The graphql fragment used here is defined in the component itself
             ...Pen
           }
           ... on ContentfulExternalLink {
@@ -104,6 +105,8 @@ export const query = graphql`
               code
             }
           }
+          # see ContentfulPost in options
+          # This is the data needed to render a link to a post
           ... on ContentfulPost {
             __typename
             contentful_id

--- a/src/utils/getTabs.tsx
+++ b/src/utils/getTabs.tsx
@@ -4,6 +4,7 @@ enum Tabs {
   JS = 'js',
   None = '',
 }
+// Used with the CodePen component to determine which tabs to show
 export const getTabs = (defaultTab: keyof typeof Tabs, showResult: boolean) => {
   const result = [];
   if (defaultTab !== 'None') {

--- a/src/utils/options.tsx
+++ b/src/utils/options.tsx
@@ -4,19 +4,54 @@ import { Options } from '@contentful/rich-text-react-renderer';
 import { BLOCKS, MARKS, INLINES } from '@contentful/rich-text-types';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { docco } from 'react-syntax-highlighter/dist/esm/styles/hljs';
-import { GatsbyImage } from 'gatsby-plugin-image';
+import { GatsbyImage, IGatsbyImageData } from 'gatsby-plugin-image';
 import { getTabs } from './getTabs';
 import { Link } from 'gatsby';
 
 interface ChildProps {
   children: ReactNode;
 }
+
 const Bold: FC<ChildProps> = ({ children }) => (
   <span className="bold">{children}</span>
 );
+
 const Text: FC<ChildProps> = ({ children }) => (
   <p className="align-center">{children}</p>
 );
+
+interface ContentfulAsset {
+  gatsbyImageData: IGatsbyImageData;
+  description: string;
+  title: string;
+}
+
+interface ContentfulCodeBlock {
+  code: {
+    code: string;
+  };
+  language: string;
+  showLineNumbers: boolean;
+}
+
+interface ContentfulCodePen {
+  hash: string;
+  editable: boolean;
+  height: number;
+  defaultTab: any;
+  showResult: boolean;
+}
+
+interface ContentfulPost {
+  slug: string;
+  title: string;
+}
+
+interface ContentfulExternalLink {
+  url: string;
+  text: string | null;
+}
+
 export const options: Options = {
   renderMark: {
     [MARKS.BOLD]: text => <Bold>{text}</Bold>,
@@ -25,7 +60,8 @@ export const options: Options = {
     [BLOCKS.PARAGRAPH]: (node, children) => <Text>{children}</Text>,
     [BLOCKS.EMBEDDED_ASSET]: node => {
       if (node.data.target.__typename === 'ContentfulAsset') {
-        const { gatsbyImageData, description, title } = node.data.target;
+        const { gatsbyImageData, description, title } = node.data
+          .target as ContentfulAsset;
         return (
           <GatsbyImage
             image={gatsbyImageData}
@@ -45,7 +81,8 @@ export const options: Options = {
     },
     [BLOCKS.EMBEDDED_ENTRY]: (node: any) => {
       if (node.data.target.__typename === 'ContentfulCodeBlock') {
-        const { code, language, showLineNumbers } = node.data.target;
+        const { code, language, showLineNumbers } = node.data
+          .target as ContentfulCodeBlock;
         return (
           <SyntaxHighlighter
             language={language}
@@ -56,8 +93,8 @@ export const options: Options = {
         );
       }
       if (node.data.target.__typename === 'ContentfulCodePen') {
-        const { hash, editable, height, defaultTab, showResult } =
-          node.data.target;
+        const { hash, editable, height, defaultTab, showResult } = node.data
+          .target as ContentfulCodePen;
         return (
           <Pen
             hash={hash}
@@ -78,7 +115,7 @@ export const options: Options = {
     },
     [INLINES.ENTRY_HYPERLINK]: (node: any, children: React.ReactNode) => {
       if (node.data.target.__typename === 'ContentfulPost') {
-        const { slug, title } = node.data.target;
+        const { slug, title } = node.data.target as ContentfulPost;
         return (
           <Link to={`/posts${slug}`} title={title}>
             {children}
@@ -93,7 +130,7 @@ export const options: Options = {
     },
     [INLINES.EMBEDDED_ENTRY]: (node: any) => {
       if (node.data.target.__typename === 'ContentfulExternalLink') {
-        const { url, text } = node.data.target;
+        const { url, text } = node.data.target as ContentfulExternalLink;
         return <ExternalLink text={text || url}>{url}</ExternalLink>;
       }
       return (


### PR DESCRIPTION
Improved TypeScript support by adding explicit typings to the Contentful model references in the render options. These type declarations ensure safer and more maintainable code by enforcing type checks for Contentful assets, code blocks, code pens, posts, and external links. This addresses potential type ambiguity and aligns with best practices for TypeScript codebases.