### PR TITLE
Improve visual spacing in tag and post lists

### DIFF
--- a/src/components/ListTags.tsx
+++ b/src/components/ListTags.tsx
@@ -7,9 +7,10 @@ const TagList = styled.ul`
   list-style: none;
   margin: 0;
   display: flex;
+  flex-wrap: wrap;
 
   ${TagListItem} {
-    margin-bottom: 0;
+    margin-bottom: 0.5rem;
     margin-right: 0.5rem;
     &:last-child {
       margin-right: 0;

--- a/src/components/posts.tsx
+++ b/src/components/posts.tsx
@@ -11,6 +11,9 @@ const PostList = styled.ul`
   flex-direction: column;
 
   ${PostListItem} {
+    & > ul {
+      margin-top: 0.5rem;
+    }
     margin-bottom: 1rem;
     ul {
       margin-left: 0.5rem;


### PR DESCRIPTION
Enhanced readability in the user interface by introducing better spacing for the tag list and post items. Tag lists now wrap to the next line with consistent bottom margin spacing, and the nested unordered lists within posts are adjusted with top margin for visual separation. This change addresses user feedback about the crowded appearance in the list displays.