### PR TITLE
Fix tag links to point to correct post URLs

### DIFF
--- a/src/components/Tags.tsx
+++ b/src/components/Tags.tsx
@@ -90,7 +90,7 @@ const Tags: React.FC = () => {
                       const { title, slug } = post;
                       return (
                         <li key={index}>
-                          <Link to={`/post/${slug}`}>{title}</Link>
+                          <Link to={`/posts${slug}`}>{title}</Link>
                         </li>
                       );
                     })}


### PR DESCRIPTION
Corrected the URL path in tag links to ensure they properly point to individual post pages, resolving navigation issues where users were led to non-existent paths. This change aids in improving user experience by facilitating accurate post discovery through tags.