### PR TITLE
Enhance post listings with dates

### DIFF
--- a/src/components/posts.tsx
+++ b/src/components/posts.tsx
@@ -24,6 +24,7 @@ const PostList = styled.ul`
 interface PostsProps {
   heading?: string | null;
   showTags?: boolean;
+  showDate?: boolean;
 }
 
 interface Post {
@@ -41,10 +42,11 @@ interface Post {
 const Posts: React.FC<PostsProps> = ({
   heading = 'All posts',
   showTags = false,
+  showDate = false,
 }) => {
   const data = useStaticQuery(graphql`
     query {
-      allContentfulPost(sort: { title: ASC }) {
+      allContentfulPost(sort: { date: DESC }) {
         nodes {
           contentful_id
           slug
@@ -80,7 +82,12 @@ const Posts: React.FC<PostsProps> = ({
                 <Link to={`/posts${slug}`} title={`${date} (${dateDiff})`}>
                   {title}
                 </Link>
-
+                {showDate && (
+                  <>
+                    <br />
+                    <span>({`${date} (${dateDiff})`})</span>
+                  </>
+                )}
                 {showTags && <ListTags tags={consolidatePostTags(postTags)} />}
               </PostListItem>
             ),

--- a/src/pages/posts.tsx
+++ b/src/pages/posts.tsx
@@ -4,7 +4,7 @@ import { Layout, Seo, Posts } from '../components';
 const PostsPage = () => (
   <Layout>
     <h1>All posts</h1>
-    <Posts heading={null} showTags />
+    <Posts heading={null} showTags showDate />
   </Layout>
 );
 


### PR DESCRIPTION
Added the option to display dates in post listings and set it to hide by default. Sorted posts in descending order by date to improve content relevance and freshness for readers