### PR TITLE
Refine sitemap page sorting order

### DIFF
--- a/src/components/sitemap.tsx
+++ b/src/components/sitemap.tsx
@@ -6,7 +6,7 @@ const SiteMap = () => {
     query {
       allSitePage(
         filter: { path: { regex: "/^((?!404).)*$/" } }
-        sort: { fields: path }
+        sort: { path: ASC }
       ) {
         edges {
           node {


### PR DESCRIPTION
Adjusted the sorting parameter in the sitemap component to ensure pages are listed in ascending order, improving the structure and readability of the sitemap.