### PR TITLE
Enhance SEO titles for tagged posts

### DIFF
--- a/src/templates/tag.tsx
+++ b/src/templates/tag.tsx
@@ -66,10 +66,13 @@ export const tags = graphql`
 
 interface HeadProps {
   pageContext: {
-    tag: string;
+    tag: { tag: string; friendlyName: string };
   };
 }
 
 export const Head = ({ pageContext }: HeadProps) => (
-  <Seo title={`Posts tagged with ${pageContext.tag}`} description={''} />
+  <Seo
+    title={`Posts tagged with ${pageContext.tag.friendlyName}`}
+    description={''}
+  />
 );


### PR DESCRIPTION
Modified the Head component to utilize a 'friendlyName' property for tags in the SEO titles, improving readability and potentially boosting SEO performance by using more descriptive, human-readable names for post tags.