### PR TITLE
Refine ExternalLink component API

### DIFF
--- a/src/components/ExternalLink.tsx
+++ b/src/components/ExternalLink.tsx
@@ -2,15 +2,15 @@ import { graphql } from 'gatsby';
 import * as React from 'react';
 
 const ExternalLink = ({
+  href,
   children,
-  text,
 }: {
-  children: string;
-  text?: string;
+  href: string;
+  children?: React.ReactNode;
 }) => {
   return (
-    <a href={children} rel="noopener noreferrer" target="_blank">
-      {text || children}
+    <a href={href} rel="noopener noreferrer" target="_blank">
+      {children || href}
     </a>
   );
 };

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -25,24 +25,24 @@ const SiteMapPage = () => (
       </p>
       <p>
         Hosting this site comes at almost no cost, thanks to the generosity of{' '}
-        <ExternalLink text="Netlify's free tier">
-          https://www.netlify.com/pricing/
+        <ExternalLink href="https://www.netlify.com/pricing/">
+          Netlify's free tier
         </ExternalLink>
         ,{' '}
-        <ExternalLink text="Contentful's free content management capabilities">
-          https://www.contentful.com/pricing/
+        <ExternalLink href="https://www.contentful.com/pricing/">
+          Contentful's free content management capabilities
         </ExternalLink>
         , and{' '}
-        <ExternalLink text="GitHub's robust version control">
-          https://github.com/pricing
+        <ExternalLink href="https://github.com/pricing">
+          GitHub's robust version control
         </ExternalLink>
-        —all underpinned by the minimal expense of domain registration. It's a
+        — all underpinned by the minimal expense of domain registration. It's a
         testament to the power and accessibility of modern web development
         tools. I even code in{' '}
-        <ExternalLink text="VS Code">
-          https://code.visualstudio.com/
+        <ExternalLink href="https://code.visualstudio.com/">
+          VS Code
         </ExternalLink>{' '}
-        —Also free. It's a great time to be a web developer!
+        — also free. It's a great time to be a web developer!
       </p>
       <p>
         As I continue to explore and expand my skill set, particularly diving

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -8,19 +8,20 @@ const SiteMapPage = () => (
     <p>Some places to try reaching out:</p>
     <ul>
       <li>
-        GitHub: <ExternalLink>https://github.com/Jim-Horn</ExternalLink>
+        GitHub: <ExternalLink href="https://github.com/Jim-Horn" />
       </li>
       <li>
-        LinkedIn:{' '}
-        <ExternalLink>https://www.linkedin.com/in/jdhorn/</ExternalLink>
+        LinkedIn: <ExternalLink href="https://www.linkedin.com/in/jdhorn/" />
       </li>
       <li>
-        Twitter: <ExternalLink>https://twitter.com/jdhorn</ExternalLink>
+        Twitter: <ExternalLink href="https://twitter.com/jdhorn" />
       </li>
     </ul>
   </Layout>
 );
 
-export const Head = () => <Seo title="Contact me" description={''} children={undefined} />;
+export const Head = () => (
+  <Seo title="Contact me" description={''} children={undefined} />
+);
 
 export default SiteMapPage;

--- a/src/utils/options.tsx
+++ b/src/utils/options.tsx
@@ -131,7 +131,7 @@ export const options: Options = {
     [INLINES.EMBEDDED_ENTRY]: (node: any) => {
       if (node.data.target.__typename === 'ContentfulExternalLink') {
         const { url, text } = node.data.target as ContentfulExternalLink;
-        return <ExternalLink text={text || url}>{url}</ExternalLink>;
+        return <ExternalLink href={url}>{text || url}</ExternalLink>;
       }
       return (
         <>


### PR DESCRIPTION
Updated the ExternalLink component for greater clarity and function, replacing 'text' and 'child' props with a single 'href' prop. This improves readability and simplifies usage across several pages, ensuring URLs are used consistently as both link destinations and display text, when alternate text is not provided. The change enhances maintenance and aligns with modern web best practices.