### PR TITLE
Refactor GraphQL query exports and streamline component barrel exports

### DIFF
--- a/src/components/CodePen.tsx
+++ b/src/components/CodePen.tsx
@@ -28,7 +28,7 @@ const Pen: React.FC<PenProps> = ({
 
 export { Pen };
 
-export const query = graphql`
+export const codePenQuery = graphql`
   fragment Pen on ContentfulCodePen {
     contentful_id
     __typename

--- a/src/components/ExternalLink.tsx
+++ b/src/components/ExternalLink.tsx
@@ -17,7 +17,7 @@ const ExternalLink = ({
 
 export { ExternalLink };
 
-export const query = graphql`
+export const externalLinkQuery = graphql`
   fragment ExternalLink on ContentfulExternalLink {
     __typename
     contentful_id

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,25 +1,11 @@
-import { ExternalLink } from './ExternalLink';
-import { Header } from './header';
-import { Layout } from './layout';
-import { ListTags } from './ListTags';
-import { Pen } from './CodePen';
-import { Posts } from './posts';
-import { Seo } from './seo';
-import { SiteMap } from './sitemap';
-import { Tags } from './Tags';
-import { PassWords } from './PassWords';
-import { ImageHeader } from './imageHeader';
-
-export {
-  ExternalLink,
-  Header,
-  Layout,
-  ListTags,
-  Pen,
-  Posts,
-  Seo,
-  SiteMap,
-  Tags,
-  PassWords,
-  ImageHeader,
-};
+export * from './ExternalLink';
+export * from './header';
+export * from './imageHeader';
+export * from './layout';
+export * from './ListTags';
+export * from './PassWords';
+export * from './CodePen';
+export * from './posts';
+export * from './seo';
+export * from './sitemap';
+export * from './Tags';


### PR DESCRIPTION
- Renamed GraphQL query exports in CodePen and ExternalLink components to avoid naming conflicts and increase clarity.
- Simplified individual export statements in the components index file to a wildcard export pattern, enhancing readability and maintainability.