### PR TITLE
Lazy load images in options utility

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,7 +4,6 @@ import { Seo, Posts, Layout } from '../components';
 
 const HomePage = () => (
   <Layout>
-    <h1>Hi</h1>
     <p>You've arrived at jdhorn.com - a work in progress</p>
     <Posts />
     <p>

--- a/src/utils/options.tsx
+++ b/src/utils/options.tsx
@@ -64,6 +64,7 @@ export const options: Options = {
           .target as ContentfulAsset;
         return (
           <GatsbyImage
+            loading="lazy"
             image={gatsbyImageData}
             alt={description}
             title={title}


### PR DESCRIPTION
Enabled lazy loading for GatsbyImage components within the options utility to improve page load performance and reduce initial page load time by deferring image loading until they are in the viewport.